### PR TITLE
Support optional fan-only accessory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build
+        env:
+          CI: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This [Homebridge](https://homebridge.io/) plugin provide an accessory for [Windmill Air Conditioners](https://windmillair.com/).
 
 ## How It Works
-This plugin exposes both a thermostat accessory and a fan accessory. The thermostat accessory controls the air conditioner's mode and temperature while the fan accessory controls the air conditioner's fan speed.
+This plugin exposes both a thermostat accessory and a fan accessory. The thermostat accessory controls the air conditioner's mode and temperature while the fan accessory controls the air conditioner's fan speed. If you are using a Windmill Fan device, you can set `fanOnly` in your configuration to hide the thermostat service.
 
 ### Thermostat
 The thermostat accessory allows you to control the air conditioner's mode and temperature. HomeKit's modes are mapped to the Windmill Air Conditioner's modes.
@@ -46,6 +46,19 @@ I recommend using the [homebridge-config-ui-x plugin](https://github.com/homebri
         "name": "Windmill AC",
         "accessory": "HomebridgeWindmillAC",
         "token": "<YOUR_WINDMILL_TOKEN>"
+    }
+]
+```
+
+To expose a Windmill Fan as only a fan service, include `"fanOnly": true`:
+
+```json
+"accessories": [
+    {
+        "name": "Windmill Fan",
+        "accessory": "HomebridgeWindmillAC",
+        "token": "<YOUR_WINDMILL_TOKEN>",
+        "fanOnly": true
     }
 ]
 ```

--- a/config.schema.json
+++ b/config.schema.json
@@ -16,6 +16,12 @@
         "type": "string",
         "required": true,
         "description": "See Configuration section from README for help."
+      },
+      "fanOnly": {
+        "title": "Fan Only",
+        "type": "boolean",
+        "default": false,
+        "description": "Set to true if you are controlling a Windmill Fan device"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "Windmill AC",
   "name": "homebridge-windmill-ac",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "description": "Control your Windmill AC with HomeKit and Siri",
   "license": "Apache-2.0",
   "repository": {

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -54,11 +54,12 @@ class WindmillThermostatAccessory implements AccessoryPlugin {
 
   public readonly name: string;
 
-  private readonly thermostatService: Service;
+  private readonly thermostatService?: Service;
   private readonly informationService: Service;
   private readonly fanService: Service;
 
   private displayUnits: number;
+  private lastFanSpeed: FanSpeed = FanSpeed.LOW;
 
 
   constructor(log: Logging, config: AccessoryConfig) {
@@ -76,31 +77,35 @@ class WindmillThermostatAccessory implements AccessoryPlugin {
       .setCharacteristic(hap.Characteristic.Manufacturer, 'The Air Lab, Inc.')
       .setCharacteristic(hap.Characteristic.Model, 'The Windmill AC');
 
-    // create a new Thermostat service
-    this.thermostatService = new hap.Service.Thermostat();
+    if (!this.config.fanOnly) {
+      // create a new Thermostat service
+      this.thermostatService = new hap.Service.Thermostat();
 
-    this.thermostatService.getCharacteristic(hap.Characteristic.CurrentHeatingCoolingState)
-      .onGet(this.handleGetCurrentHeatingCoolingState.bind(this));
+      this.thermostatService.getCharacteristic(hap.Characteristic.CurrentHeatingCoolingState)
+        .onGet(this.handleGetCurrentHeatingCoolingState.bind(this));
 
-    this.thermostatService.getCharacteristic(hap.Characteristic.TargetHeatingCoolingState)
-      .onGet(this.handleGetTargetHeatingCoolingState.bind(this))
-      .onSet(this.handleSetTargetHeatingCoolingState.bind(this));
+      this.thermostatService.getCharacteristic(hap.Characteristic.TargetHeatingCoolingState)
+        .onGet(this.handleGetTargetHeatingCoolingState.bind(this))
+        .onSet(this.handleSetTargetHeatingCoolingState.bind(this));
 
-    this.thermostatService.getCharacteristic(hap.Characteristic.CurrentTemperature)
-      .onGet(this.handleGetCurrentTemperature.bind(this));
+      this.thermostatService.getCharacteristic(hap.Characteristic.CurrentTemperature)
+        .onGet(this.handleGetCurrentTemperature.bind(this));
 
-    this.thermostatService.getCharacteristic(hap.Characteristic.TargetTemperature)
-      .setProps({
-        minValue: fahrenheitToCelsius(60),
-        maxValue: fahrenheitToCelsius(86),
-        minStep: 1,
-      })
-      .onGet(this.handleGetTargetTemperature.bind(this))
-      .onSet(this.handleSetTargetTemperature.bind(this));
+      this.thermostatService.getCharacteristic(hap.Characteristic.TargetTemperature)
+        .setProps({
+          minValue: fahrenheitToCelsius(60),
+          maxValue: fahrenheitToCelsius(86),
+          // Use a one-degree Fahrenheit step
+          minStep: fahrenheitToCelsius(1),
+        })
+        .onGet(this.handleGetTargetTemperature.bind(this))
+        .onSet(this.handleSetTargetTemperature.bind(this));
 
-    this.thermostatService.getCharacteristic(hap.Characteristic.TemperatureDisplayUnits)
-      .onGet(this.handleGetTemperatureDisplayUnits.bind(this))
-      .onSet(this.handleSetTemperatureDisplayUnits.bind(this));
+
+      this.thermostatService.getCharacteristic(hap.Characteristic.TemperatureDisplayUnits)
+        .onGet(this.handleGetTemperatureDisplayUnits.bind(this))
+        .onSet(this.handleSetTemperatureDisplayUnits.bind(this));
+    }
 
     // create a new Fan service
     this.fanService = new hap.Service.Fanv2();
@@ -114,9 +119,13 @@ class WindmillThermostatAccessory implements AccessoryPlugin {
       .onSet(this.handleSetFanRotationSpeed.bind(this));
 
 
-    // Set the thermostat service as the primary service
-    this.thermostatService.setPrimaryService(true);
-    this.fanService.setPrimaryService(false);
+    if (this.config.fanOnly) {
+      this.fanService.setPrimaryService(true);
+    } else {
+      // Set the thermostat service as the primary service
+      this.thermostatService!.setPrimaryService(true);
+      this.fanService.setPrimaryService(false);
+    }
     this.informationService.setPrimaryService(false);
   }
 
@@ -297,7 +306,23 @@ class WindmillThermostatAccessory implements AccessoryPlugin {
 
     // If the fan is turned off, set the fan speed to AUTO
     if(value === hap.Characteristic.Active.INACTIVE) {
+      const currentSpeed = await this.windmill.getFanSpeed();
+      if(currentSpeed !== FanSpeed.AUTO) {
+        this.lastFanSpeed = currentSpeed;
+      }
       await this.windmill.setFanSpeed(FanSpeed.AUTO);
+      return;
+    }
+
+    const power = await this.windmill.getPower();
+    if(!power) {
+      await this.windmill.setPower(true);
+      await this.windmill.setMode(Mode.FAN);
+    }
+
+    const currentSpeed = await this.windmill.getFanSpeed();
+    if(currentSpeed === FanSpeed.AUTO) {
+      await this.windmill.setFanSpeed(this.lastFanSpeed);
     }
   }
 
@@ -332,18 +357,29 @@ class WindmillThermostatAccessory implements AccessoryPlugin {
 
     const intValue = parseInt(value.toString(), 10);
 
-    // If value is 0, the fan speed will be set to AUTO by `handleSetFanActive`
     if (intValue === 0) {
+      await this.windmill.setFanSpeed(FanSpeed.AUTO);
+      await this.fanService.updateCharacteristic(hap.Characteristic.Active, hap.Characteristic.Active.INACTIVE);
       return;
     }
 
-    if (intValue <= 33) {
-      await this.windmill.setFanSpeed(FanSpeed.LOW);
-    } else if (intValue <= 66) {
-      await this.windmill.setFanSpeed(FanSpeed.MEDIUM);
-    } else if (intValue <= 100) {
-      await this.windmill.setFanSpeed(FanSpeed.HIGH);
+    if(!await this.windmill.getPower()) {
+      await this.windmill.setPower(true);
+      await this.windmill.setMode(Mode.FAN);
     }
+
+    let speed: FanSpeed;
+    if (intValue <= 33) {
+      speed = FanSpeed.LOW;
+    } else if (intValue <= 66) {
+      speed = FanSpeed.MEDIUM;
+    } else {
+      speed = FanSpeed.HIGH;
+    }
+
+    await this.windmill.setFanSpeed(speed);
+    this.lastFanSpeed = speed;
+    await this.fanService.updateCharacteristic(hap.Characteristic.Active, hap.Characteristic.Active.ACTIVE);
   }
 
   /*
@@ -351,11 +387,16 @@ class WindmillThermostatAccessory implements AccessoryPlugin {
    * It should return all services which should be added to the accessory.
    */
   getServices(): Service[] {
-    return [
-      this.thermostatService,
+    const services = [
       this.informationService,
       this.fanService,
     ];
+
+    if (!this.config.fanOnly && this.thermostatService) {
+      services.unshift(this.thermostatService);
+    }
+
+    return services;
   }
 
 }

--- a/src/services/WindmillService.ts
+++ b/src/services/WindmillService.ts
@@ -68,14 +68,40 @@ export class WindmillService extends BlynkService {
     this.log.debug('Getting mode');
     const value = await this.getPinValue(Pin.MODE);
     this.log.debug(`Mode is ${value}`);
-    return value as Mode;
+    // The value returned from the API is a number represented as a string.
+    // Convert it to the corresponding Mode enum value.
+    switch (parseInt(value, 10)) {
+      case ModeInt.FAN:
+        return Mode.FAN;
+      case ModeInt.COOL:
+        return Mode.COOL;
+      case ModeInt.ECO:
+        return Mode.ECO;
+      default:
+        this.log.warn(`Unknown mode value '${value}'`);
+        return Mode.FAN;
+    }
   }
 
   public async getFanSpeed(): Promise<FanSpeed> {
     this.log.debug('Getting fan speed');
     const value = await this.getPinValue(Pin.FAN);
     this.log.debug(`Fan speed is ${value}`);
-    return value as FanSpeed;
+    // The API returns a number represented as a string. Convert it to the
+    // corresponding FanSpeed enum value.
+    switch (parseInt(value, 10)) {
+      case FanSpeedInt.AUTO:
+        return FanSpeed.AUTO;
+      case FanSpeedInt.LOW:
+        return FanSpeed.LOW;
+      case FanSpeedInt.MEDIUM:
+        return FanSpeed.MEDIUM;
+      case FanSpeedInt.HIGH:
+        return FanSpeed.HIGH;
+      default:
+        this.log.warn(`Unknown fan speed value '${value}'`);
+        return FanSpeed.AUTO;
+    }
   }
 
   public async setPower(value: boolean): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,4 +2,5 @@ import { AccessoryConfig } from 'homebridge';
 
 export interface WindmillThermostatAccessoryConfig extends AccessoryConfig {
     token: string;
+    fanOnly?: boolean;
 }


### PR DESCRIPTION
## Summary
- add `fanOnly` option to config schema and types
- make thermostat service optional when `fanOnly` is true
- document fan-only configuration in README
- update CI to run on Node 20
- merge with master and fix lint errors

## Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843b86846848333b9940d5a711b0249