### PR TITLE
Implement stricter typings

### DIFF
--- a/src/services/BlynkService.ts
+++ b/src/services/BlynkService.ts
@@ -25,7 +25,7 @@ export class BlynkService {
    * @param pin The virtual pin to get the value of (e.g. V1)
    * @returns The value of the pin
    */
-  protected async getPinValue(pin: string) {
+  protected async getPinValue(pin: string): Promise<string> {
     const url = new URL('/external/api/get', this.serverAddress);
     url.searchParams.append('token', this.token);
     url.searchParams.append(pin, '');

--- a/src/services/WindmillService.ts
+++ b/src/services/WindmillService.ts
@@ -3,7 +3,7 @@ import { BlynkService } from './BlynkService';
 
 const BASE_URL = 'https://dashboard.windmillair.com';
 
-export enum Pin {
+export const enum Pin {
     POWER = 'V0',
     CURRENT_TEMP = 'V1',
     TARGET_TEMP = 'V2',
@@ -11,26 +11,26 @@ export enum Pin {
     FAN = 'V4',
 }
 
-enum ModeInt {
+const enum ModeInt {
     FAN = 0,
     COOL = 1,
     ECO = 2,
 }
 
-export enum Mode {
+export const enum Mode {
     FAN = 'Fan',
     COOL = 'Cool',
     ECO = 'Eco',
 }
 
-enum FanSpeedInt {
+const enum FanSpeedInt {
     AUTO = 0,
     LOW = 1,
     MEDIUM = 2,
     HIGH = 3,
 }
 
-export enum FanSpeed {
+export const enum FanSpeed {
     AUTO = 'Auto',
     LOW = 'Low',
     MEDIUM = 'Medium',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "noImplicitAny": false
+    "noImplicitAny": true
   },
   "include": [
     "src/"


### PR DESCRIPTION
## Summary
- enforce `noImplicitAny` in TypeScript config
- type BlynkService's `getPinValue` method
- mark WindmillService enums as `const`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68479c8baed48333b8377ae7dd167159