### PR TITLE
Implement HttpClient abstraction

### DIFF
--- a/src/services/BlynkService.ts
+++ b/src/services/BlynkService.ts
@@ -1,9 +1,10 @@
-import fetch from 'node-fetch';
-import { URL } from 'url';
+import { URL } from 'url'
+import { HttpClient, FetchHttpClient } from './HttpClient'
 
 export interface BlynkServiceConfig {
-    serverAddress: string;
-    token: string;
+    serverAddress: string
+    token: string
+    httpClient?: HttpClient
 }
 
 /**
@@ -13,10 +14,12 @@ export interface BlynkServiceConfig {
 export class BlynkService {
   protected readonly serverAddress: string;
   protected readonly token: string;
+  protected readonly httpClient: HttpClient
 
-  constructor({ serverAddress, token }: BlynkServiceConfig) {
-    this.serverAddress = serverAddress;
-    this.token = token;
+  constructor({ serverAddress, token, httpClient }: BlynkServiceConfig) {
+    this.serverAddress = serverAddress
+    this.token = token
+    this.httpClient = httpClient ?? new FetchHttpClient()
   }
 
   /**
@@ -30,15 +33,7 @@ export class BlynkService {
     url.searchParams.append('token', this.token);
     url.searchParams.append(pin, '');
 
-    const response = await fetch(url.toString());
-
-    if (!response.ok) {
-      throw new Error(`Failed to get pin value for ${pin}`);
-    }
-
-    const text = await response.text();
-
-    return text;
+    return this.httpClient.get(url.toString())
   }
 
   /**
@@ -52,14 +47,7 @@ export class BlynkService {
     url.searchParams.append('token', this.token);
     url.searchParams.append(pin, value);
 
-    const response = await fetch(url.toString());
-
-    if (!response.ok) {
-      throw new Error(`Failed to set pin value for ${pin}`);
-    }
-
-    const text = await response.text();
-
-    return text === '1';
+    const text = await this.httpClient.get(url.toString())
+    return text === '1'
   }
 }

--- a/src/services/HttpClient.ts
+++ b/src/services/HttpClient.ts
@@ -1,0 +1,27 @@
+import fetch from 'node-fetch'
+export interface HttpClient {
+  get(url: string): Promise<string>
+  post(url: string, body: unknown): Promise<string>
+}
+
+export class FetchHttpClient implements HttpClient {
+  async get(url: string): Promise<string> {
+    const res = await fetch(url)
+    if (!res.ok) {
+      throw new Error(`GET request failed for ${url}`)
+    }
+    return res.text()
+  }
+
+  async post(url: string, body: unknown): Promise<string> {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body ?? {}),
+    })
+    if (!res.ok) {
+      throw new Error(`POST request failed for ${url}`)
+    }
+    return res.text()
+  }
+}

--- a/src/services/WindmillService.ts
+++ b/src/services/WindmillService.ts
@@ -1,5 +1,6 @@
-import { Logging } from 'homebridge';
-import { BlynkService } from './BlynkService';
+import { Logging } from 'homebridge'
+import { BlynkService } from './BlynkService'
+import { HttpClient } from './HttpClient'
 
 const BASE_URL = 'https://dashboard.windmillair.com';
 
@@ -39,8 +40,8 @@ export enum FanSpeed {
 
 export class WindmillService extends BlynkService {
 
-  constructor(token: string, private readonly log: Logging) {
-    super({ serverAddress: BASE_URL, token });
+  constructor(token: string, private readonly log: Logging, httpClient?: HttpClient) {
+    super({ serverAddress: BASE_URL, token, httpClient })
   }
 
   public async getPower(): Promise<boolean> {


### PR DESCRIPTION
## Summary
- introduce `HttpClient` and `FetchHttpClient`
- refactor `BlynkService` to use the new http client
- allow `WindmillService` to inject an http client implementation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68479c86e6e8833390082733ad987b66