### PR TITLE
Update docs for node 18 and accessory info

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # the Node.js versions to build on
-        node-version: [12.x, 13.x, 14.x, 15.x, 16.x]
+        node-version: [18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # homebridge-windmill-ac
 This [Homebridge](https://homebridge.io/) plugin provide an accessory for [Windmill Air Conditioners](https://windmillair.com/).
 
+## Requirements
+* Node.js 18 or later
+
+
 ## How It Works
 This plugin exposes both a thermostat accessory and a fan accessory. The thermostat accessory controls the air conditioner's mode and temperature while the fan accessory controls the air conditioner's fan speed.
+
+## Accessory Classes
+- `WindmillThermostatAccessory` &ndash; main accessory exposing thermostat and fan services.
+- `WindmillService` &ndash; wraps the Windmill API.
+- `BlynkService` &ndash; generic helper for the Blynk API.
 
 ### Thermostat
 The thermostat accessory allows you to control the air conditioner's mode and temperature. HomeKit's modes are mapped to the Windmill Air Conditioner's modes.
@@ -40,6 +49,7 @@ First, get your token from the Windmill dashboard.
 I recommend using the [homebridge-config-ui-x plugin](https://github.com/homebridge/homebridge-config-ui-x) or [HOOBS](https://hoobs.com/) to configure the plugin.
 
 ### JSON Configuration
+Add the accessory to the `accessories` section of your Homebridge config:
 ```json
 "accessories": [
     {
@@ -48,4 +58,12 @@ I recommend using the [homebridge-config-ui-x plugin](https://github.com/homebri
         "token": "<YOUR_WINDMILL_TOKEN>"
     }
 ]
+```
+
+## Testing
+Run the linter and build the project before publishing:
+
+```bash
+npm run lint
+npm run build
 ```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/johnanthonyeletto/homebridge-windmill-ac/issues"
   },
   "engines": {
-    "node": ">=14.18.1",
+    "node": ">=18.0.0",
     "homebridge": ">=1.3.5"
   },
   "main": "dist/accessory.js",
@@ -30,7 +30,7 @@
     "node-fetch": "^2.6.11"
   },
   "devDependencies": {
-    "@types/node": "^16.10.9",
+    "@types/node": "^18.0.0",
     "@types/node-fetch": "^2.6.3",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",


### PR DESCRIPTION
## Summary
- document Node 18+ requirement
- describe accessory classes in the README
- update configuration example and testing instructions
- bump Node requirement in package.json
- test workflow now uses Node 18 and 20

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: rimraf not found / TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68479c9ee1c08333bf35a44f3cfa4d20